### PR TITLE
Added discovery of JVM and support for default value of process as '*'

### DIFF
--- a/config_handler/mapping/metrics_plugins_mapping.yaml
+++ b/config_handler/mapping/metrics_plugins_mapping.yaml
@@ -236,7 +236,7 @@ jvm:
      min: ''
      dataType: string
      max: ''
-     defaultValue: ''
+     defaultValue: '*'
      tooltip: Name of java process
      label: Process
      fieldName: process


### PR DESCRIPTION
Update:
- Checking if java processes are running using the command 'jcmd'
- If the command gives an output with pids and java processes, add JVM to discovered services
- Previously the default process field value for jvm plugin was "", changing it to "*" to get all java process metrics as default
