### PR TITLE
Disabling JVM plugin if the service plugin is already collecting jvm …

### DIFF
--- a/service_discovery/discovery.py
+++ b/service_discovery/discovery.py
@@ -122,6 +122,7 @@ SERVICE_PLUGIN_MAPPING = {
 }
 POLLER_PLUGIN = ["elasticsearch"]
 JMX_PLUGINS = ["kafka.Kafka", "zookeeper"]
+JVM_ENABLED_PLUGINS = ["kafka.Kafka", "zookeeper", "elasticsearch", "tomcat"]
 HADOOP_SERVICE = {
     "yarn-rm-log": { \
          "service-name": "org.apache.hadoop.yarn.server.resourcemanager.ResourceManager",
@@ -498,6 +499,11 @@ def discover_services():
         pid = get_process_id(service)
         if pid:
             service_list.add(service)
+
+    for service in JVM_ENABLED_PLUGINS:
+        if service in service_list and 'jvm' in service_list:
+            service_list.remove('jvm')
+            break
 
     for service in service_list:
         # For all services in service_list, add config for agent, loggers and pollers.

--- a/service_discovery/discovery.py
+++ b/service_discovery/discovery.py
@@ -60,7 +60,7 @@ SERVICE_NAME = {
     "yarn": "yarn",
     "hdfs": "hdfs",
     "spark2": "spark2",
-    "jvm": "JVM",
+    "jvm": "JMX",
     "jmeter": "jmeter",
     "node-exporter": "linux",
     "mysql-exporter": "mysql",
@@ -467,6 +467,12 @@ def discover_prometheus_services(discovery):
             if SERVICE_NAME[service] not in discovery:
                 discovery[SERVICE_NAME[service]] = []
             discovery[SERVICE_NAME[service]].append(final_dict)
+	
+	for service in JVM_ENABLED_PLUGINS:
+            if SERVICE_NAME[service] in discovery and SERVICE_NAME['jmx-exporter'] in discovery:
+                discovery.pop('JMX')
+                break
+
     return discovery
 
 


### PR DESCRIPTION
…metrics

Update:
- Kafka, zookeeper, tomcat and elasticsearch already collect jvm metrics as part of their plugin metrics.
- If any of the above services are discovered, then jvm plugin is not discovered.
- If java processes other than the above mentioned are discovered, then jvm plugin is enabled.