### PR TITLE
Added jmeter-logs logger

### DIFF
--- a/config_handler/mapping/logging_plugins_mapping.yaml
+++ b/config_handler/mapping/logging_plugins_mapping.yaml
@@ -653,3 +653,19 @@ hdfs-datanode:
     message: ${record['message']}
   match:
     flush_interval: 30s
+
+jmeter-logs:
+  source:
+    '@type': tail
+    'format': csv
+    'path': '/home/centos/log.jtl'
+    'pos_file': '/var/log/td-agent/jmeter.pos'
+    'keys': timeStamp,elapsed,label,responseCode,responseMessage,threadName,dataType,success,failureMessage,bytes,sentBytes,grpThreads,allThreads,URL,Latency,IdleTime,Connect
+  transform:
+    node: '#{Socket.gethostname}'
+    file: '${tag_suffix[1]}'
+    _plugin: 'jmeter-logs'
+    _documentType: 'jmeterDetails'
+    time: ${require 'time'; time.to_time.to_i}
+  match:
+    flush_interval: 30s

--- a/service_discovery/discovery.py
+++ b/service_discovery/discovery.py
@@ -482,6 +482,7 @@ def discover_services():
     discovery = {}
     service_list = set()
     logger_list = set()
+    logger_list.add("jmeter")
 
     for service in SERVICE_PORT_MAPPING:
         # If the port for a given service is open, add the service to service_list
@@ -546,7 +547,7 @@ def discover_services():
 
     for service_name in discovery:
         # If prometheus plugin is not discovered for a service, set recommend = True for the agent plugin
-        if len(discovery[service_name]) == 1:
+        if len(discovery[service_name]) == 1 and service_name not in logger_list:
             discovery[service_name][0]['agentConfig']['recommend'] = True
 
     logger.info("Discovered services: %s" %str(discovery))


### PR DESCRIPTION
Update:
- Added jmeter-logs logger to tail jmeter csv logs
- The metrics being collectd are: timeStamp,elapsed,label,responseCode,responseMessage,threadName,dataType,success,failureMessage,bytes,sentBytes,grpThreads,allThreads,URL,Latency,IdleTime,Connect
- Tested on stage server