### PR TITLE
Updated jmeter logger to have name 'jmeter'

### DIFF
--- a/config_handler/mapping/logging_plugins_mapping.yaml
+++ b/config_handler/mapping/logging_plugins_mapping.yaml
@@ -654,7 +654,7 @@ hdfs-datanode:
   match:
     flush_interval: 30s
 
-jmeter-logs:
+jmeter:
   source:
     '@type': tail
     'format': csv
@@ -664,7 +664,7 @@ jmeter-logs:
   transform:
     node: '#{Socket.gethostname}'
     file: '${tag_suffix[1]}'
-    _plugin: 'jmeter-logs'
+    _plugin: 'jmeter'
     _documentType: 'jmeterDetails'
     time: ${require 'time'; time.to_time.to_i}
   match:


### PR DESCRIPTION
Update:
-Updated jmeter fluentd plugin to have name as 'jmeter' with doc type 'jmeterDetails'