### PR TITLE
Updated mapping of topstats

### DIFF
--- a/config_handler/mapping/metrics_plugins_mapping.yaml
+++ b/config_handler/mapping/metrics_plugins_mapping.yaml
@@ -499,7 +499,7 @@ topstats:
      Mandatory: true
      dataType: list
      multiselect: false
-     defaultValue: 'Top 5 CPU util'
+     defaultValue: 'CPU'
      options:
       - label: 'Top 5 CPU util'
         value: 'CPU'

--- a/service_discovery/discovery.py
+++ b/service_discovery/discovery.py
@@ -98,7 +98,7 @@ Mapping for services and the plugin to be configured for them.
 '''
 SERVICE_PLUGIN_MAPPING = {
     "topstats": "topstats",
-    "elasticsearch": "elasticsearch",
+    "elasticsearch": "elasticsearchagent",
     "apache": "apache",
     "tomcat": "tomcat",
     "haproxy": "haproxy",


### PR DESCRIPTION
Update:
- Changed defaultValue of topstats plugin to 'CPU' instead of 'Top 5 CPU util' as 'Top 5 CPU util' is only the label name, not the value expected.
- In discovery, mapped elasticsearch service to include elasticsearchagent plugin