### PR TITLE
Fix for bug SPP-136

### DIFF
--- a/config_handler/fluentd_manager.py
+++ b/config_handler/fluentd_manager.py
@@ -320,6 +320,7 @@ class FluentdPluginManager:
                 lines.extend(['\t</parse>', '</filter>'])
             source_tag = '*.'+ source_tag
         elif 'parse' in data:
+	    time_format = ""
             # Add parser filter. if data.get('match').has_key('tag'):
             if 'tag' in data.get('match'):
                 lines.append('\n<filter ' + source_tag + '.' +
@@ -328,11 +329,15 @@ class FluentdPluginManager:
 		lines.append('\n<filter ' + source_tag + '*>')
 	    lines.extend(['\t@type parser', '\tkey_name message', '\t<parse>'])
 	    for key, val in data.get('parse', {}).iteritems():
+		if key == "time_format":
+                        time_format = val
 		if key == "expressions":
 		    for v in val:
 			lines.append('\t\t' + "<pattern>")
 			lines.append('\t\t\t' + 'format regexp')
 			lines.append('\t\t\t' + 'expression ' + v)
+			if time_format:
+                                lines.append('\t\t\t' + 'time_format ' + time_format)
 			lines.append('\t\t' + "</pattern>")
 		    continue
 		lines.append('\t\t' + key  + ' ' + val)

--- a/config_handler/mapping/logging_plugins_mapping.yaml
+++ b/config_handler/mapping/logging_plugins_mapping.yaml
@@ -212,19 +212,21 @@ nginx-access:
     path: '/var/log/nginx/access.log'
     pos_file: '/var/log/td-agent/nginx_access.pos'
   parse:
-    '@type': regexp
+    '@type': multi_format
     time_format: '%d/%b/%Y:%H:%M:%S %z'
-    #expression: '^(?<host>[^ ]*)\s-(?<user>[^-]*)-\s\[(?<time>[^\]]*)\]\s\"(?<method>[^ ]*)\s(?<path>[^"]*)\"\s(?<code>[^ ]*)\s(?<size>[^ ]*)\s\"(?<referer>[^"]*)\"\s\"(?<agent>[^"]*)\"\s\"(?<response_time>[^"]*)\"$'
-    expression: '^(?<host>[^ ]*)\s(?<user>[^ ]*)\s\[(?<time>[^\]]*)\]\s\"(?<method>[^ ]*)\s(?<path>[^"]*)\s(?<header>[^ ]*)\"\s(?<code>[^ ]*)\s(?<size>[^ ]*)\s\"(?<referer>[^"]*)\"\s\"(?<agent>[^"]*)\"\s\"(?<referer2>[^"]*)\"\s(rt=(?<request_time>[^ ]*))\s(uct=(?<upstream_connect_time>[^ ]*))\s(uht=(?<upstream_header_time>[^ ]*))\s(urt=(?<upstream_response_time>[^ ]*))$'
+    expressions:
+     - '/^(?<host>[^ ]*)\s(?<user>[^ ]*)\s\[(?<time>[^\]]*)\]\s\"(?<method>[^ ]*)\s(?<path1>\/[a-z,A-Z,\/]*)(?<id1>\d+)(?<path2>[a-z,A-Z,\/]+)(?<id2>\d+)(?<path3>[a-z,A-Z,\/]*)\s(?<header>[^ ]*)\"\s(?<code>[^ ]*)\s(?<size>[^ ]*)\s\"(?<referer>[^"]*)\"\s\"(?<agent>[^"]*)\"\s\"(?<referer2>[^"]*)\"\s(rt=(?<request_time>[^ ]*))\s(uct=(?<upstream_connect_time>[^ ]*))\s(uht=(?<upstream_header_time>[^ ]*))\s(urt=(?<upstream_response_time>[^ ]*))$/'
+     - '/^(?<host>[^ ]*)\s(?<user>[^ ]*)\s\[(?<time>[^\]]*)\]\s\"(?<method>[^ ]*)\s(?<path1>\/[a-z,A-Z,\/]*)(?<id>\d+)(?<path2>[a-z,A-Z,\/]*)\s(?<header>[^ ]*)\"\s(?<code>[^ ]*)\s(?<size>[^ ]*)\s\"(?<referer>[^"]*)\"\s\"(?<agent>[^"]*)\"\s\"(?<referer2>[^"]*)\"\s(rt=(?<request_time>[^ ]*))\s(uct=(?<upstream_connect_time>[^ ]*))\s(uht=(?<upstream_header_time>[^ ]*))\s(urt=(?<upstream_response_time>[^ ]*))$/'
+     - '/^(?<host>[^ ]*)\s(?<user>[^ ]*)\s\[(?<time>[^\]]*)\]\s\"(?<method>[^ ]*)\s(?<path>[^"]*)\s(?<header>[^ ]*)\"\s(?<code>[^ ]*)\s(?<size>[^ ]*)\s\"(?<referer>[^"]*)\"\s\"(?<agent>[^"]*)\"\s\"(?<referer2>[^"]*)\"\s(rt=(?<request_time>[^ ]*))\s(uct=(?<upstream_connect_time>[^ ]*))\s(uht=(?<upstream_header_time>[^ ]*))\s(urt=(?<upstream_response_time>[^ ]*))$/'
     'types': request_time:float,upstream_connect_time:float,upstream_header_time:float,upstream_response_time:float,size:integer
   transform:
-    node: '#{Socket.gethostname}'
-    file: '${tag_suffix[1]}'
+    node: '#{Socket.gethostname}' 
+    file: '${tag_suffix[1]}' 
     _plugin: 'nginx'
     _documentType: 'nginxAccessLogs'
     time: ${require 'time'; time.to_time.to_i}
     level: 'info'
-    message: "${record['method']+' '+record['path']}"
+    path: ${if record['path'] != nil then record['path'] elsif record['id2'] == nil then record['path1'] + '[id]' + record['path2'] else record['path1'] + '[id]' + record['path2'] + '[id]' + record['path3'] end}
   match:
     flush_interval: 30s
 


### PR DESCRIPTION
Update:
- Added multi_format for nginx-access log with 3 regex expressions
- These expressions match the numerical 'id' within a path
- This numerical 'id' is parameterized and sent as the keyword '[id]' in the 'path'
- Added code in fluentd_manager to add time_format to every pattern when time_format is specified with multiple expressions
- Tested on stage server