### PR TITLE
Fixed issue: discovery failing on jmeter

### DIFF
--- a/service_discovery/discovery.py
+++ b/service_discovery/discovery.py
@@ -599,7 +599,7 @@ def discover_services():
 
     for service_name in discovery:
         for plugin in discovery[service_name]:
-            if (plugin['agentConfig']["name"]).startswith("prometheus"):
+            if plugin['agentConfig'].get('name') and (plugin['agentConfig']["name"]).startswith("prometheus"):
                 recommend_agents_off.add(service_name)
 
     for service_name in discovery:


### PR DESCRIPTION
Issue:
- We set the recommendation for agent plugins by testing the presence of a name starting with 'prometheus'
- For services where only loggers are present but no agent plugin, the search for an agent name caused a KeyError
Update:
- This issue is fixed by checking for the presence of the key first and then checking for 'prometheus' phrase in the key
- Tested on stage server