### PR TITLE
Changing elasticsearch document type

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -89,7 +89,7 @@ HEARTBEAT = "heartbeat"
 HEARTBEAT_INTERVAL = "heartbeat_interval"
 
 COMPONENTS = "components"
-DOCUMENT = "_doc"
+DOCUMENT = "doc"
 
 CUSTOM_HOSTNAME = "custom_hostname"
 NODEID = "NodeId"


### PR DESCRIPTION
Update:
- Previously, '_doc' was used as the document type for elasticseach index mapping
- Changing this to 'doc' to conform with the document type name used by stacktrace
- Tested on stage server