### PR TITLE
Reverting change for elasticsearch mapping doc type

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -89,7 +89,7 @@ HEARTBEAT = "heartbeat"
 HEARTBEAT_INTERVAL = "heartbeat_interval"
 
 COMPONENTS = "components"
-DOCUMENT = "doc"
+DOCUMENT = "_doc"
 
 CUSTOM_HOSTNAME = "custom_hostname"
 NODEID = "NodeId"


### PR DESCRIPTION
Update:
- Changing elasticsearch doc type name from 'doc' to '_doc'
- The doc type name will be changed back to 'doc' once the changes are tested and included in the master branch of sf-apm-server repo