### PR TITLE
Feature: Using two datasources in fluentd - metric type and logger type

### DIFF
--- a/config_handler/configurator.py
+++ b/config_handler/configurator.py
@@ -272,12 +272,12 @@ def get_target_status():
         fluent_exsting_data = json.loads(exsting_data)
         if fluent_exsting_data:
             for target in fluent_exsting_data['targets']:
-		target_details = {}
+                target_details = {}
                 target_details["name"] = target["name"]
                 target_details["index"] = target["index"]
                 target_details["status"] = get_elasticsearch_status(target["host"], target["index"], target["port"])
                 target_details["type"] = "fluentd"
-		if 'store_type' in target and target['store_type'] == 'metric':
+                if 'store_type' in target and target['store_type'] == 'metric':
                     target_details["store_type"] = "metric"
                 else:
                     target_details["store_type"] = "logger"

--- a/config_handler/configurator.py
+++ b/config_handler/configurator.py
@@ -272,10 +272,15 @@ def get_target_status():
         fluent_exsting_data = json.loads(exsting_data)
         if fluent_exsting_data:
             for target in fluent_exsting_data['targets']:
+		target_details = {}
                 target_details["name"] = target["name"]
                 target_details["index"] = target["index"]
                 target_details["status"] = get_elasticsearch_status(target["host"], target["index"], target["port"])
                 target_details["type"] = "fluentd"
+		if 'store_type' in target and target['store_type'] == 'metric':
+                    target_details["store_type"] = "metric"
+                else:
+                    target_details["store_type"] = "logger"
                 target_status.append(target_details)
         else:
             logger.error("No workload data found in fluentd_data.json")

--- a/config_handler/fluentd_manager.py
+++ b/config_handler/fluentd_manager.py
@@ -148,12 +148,12 @@ class FluentdPluginManager:
             temp['source'] = {}
             temp['source']['tag'] = x_plugin.get('tags', {})
             temp['name'] = x_plugin.get(NAME)
-	    temp['collection_type'] = 'logger'
+            temp['collection_type'] = 'logger'
 
             if x_plugin.get(NAME) in self.plugin_config.keys():
                 plugin = self.plugin_config.get(
                     x_plugin.get(NAME))
-		temp['collection_type'] = plugin.get('collection_type', '')
+                temp['collection_type'] = plugin.get('collection_type', '')
                 if x_plugin.get(NAME) == 'esalogstore':
                     temp['esalogsdownload'] = {}
                     temp['esalogsdownload'].update(plugin.get('esalogsdownload'))
@@ -392,7 +392,7 @@ class FluentdPluginManager:
                                  data.get('match').get('tag') + '>')
                     data.get('match').pop('tag')
 
-		if data.get('collection_type', '') == 'metric':
+                if data.get('collection_type', '') == 'metric':
                     if x_targets.get("store_type") and x_targets['store_type'] == 'metric':
                         lines.append('\n<match ' + source_tag + '*>')
                         for key, val in x_targets.iteritems():

--- a/config_handler/mapping/logging_plugins_mapping.yaml
+++ b/config_handler/mapping/logging_plugins_mapping.yaml
@@ -27,6 +27,7 @@ mysql-error:
     flush_interval: 30s
 
 mysql-general:
+  collection_type: metric
   source:
     '@type': tail
     path: '/var/log/mysql/mysql.log, /var/log/mysql.log, /var/log/mysqld.log'
@@ -59,6 +60,7 @@ mysql-general:
 
 # mysql slow query log
 mysql-slowquery:
+  collection_type: metric
   source:
     '@type': tail
     path: '/var/lib/mysql/ip-*slow.log'
@@ -114,6 +116,7 @@ apache-error:
    match:
      flush_interval: 30s
 apache-access:
+   collection_type: metric
    source:
      '@type': tail
 #     format: '/^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" (?<response_time>[^ ]*))?$/'
@@ -209,6 +212,7 @@ nginx-error:
 
 #NGINX access logging mapping
 nginx-access:
+  collection_type: metric
   source:
     '@type': tail
     path: '/var/log/nginx/access.log'
@@ -235,6 +239,7 @@ nginx-access:
 
 #postgres logging mapping
 postgres-general:
+  collection_type: metric
   source:
     '@type': tail
     path: '/var/lib/pgsql/9.6/data/pg_log/postgresql-Sun.log, /var/lib/pgsql/9.6/data/pg_log/postgresql-Sat.log, /var/lib/pgsql/9.6/data/pg_log/postgresql-Fri.log, /var/lib/pgsql/9.6/data/pg_log/postgresql-Thu.log, /var/lib/pgsql/9.6/data/pg_log/postgresql-Wed.log,  /var/lib/pgsql/9.6/data/pg_log/postgresql-Tue.log, /var/lib/pgsql/9.6/data/pg_log/postgresql-Mon.log, /var/log/postgresql/postgresql-10-main.log'
@@ -682,6 +687,7 @@ hdfs-datanode:
     flush_interval: 30s
 
 jmeter:
+  collection_type: metric
   source:
     '@type': tail
     'format': csv

--- a/config_handler/mapping/targets_mapping.yaml
+++ b/config_handler/mapping/targets_mapping.yaml
@@ -6,3 +6,4 @@ elasticsearch:
  host: "Host Ip required"
  port: "Port required "
  index: "Index required"
+ store_type: "Store type required"

--- a/service_discovery/discovery.py
+++ b/service_discovery/discovery.py
@@ -448,6 +448,10 @@ def add_logger_config(service_dict, service):
             log_config["name"] = item
             log_config["recommend"] = True
             log_config["selected"] = True
+	    if 'collection_type' in value and value['collection_type'] == 'metric':
+                log_config['fluentd_type'] = "fluentd_agent"
+            else:
+                log_config['fluentd_type'] = "fluentd_logging"
             log_config["config"] = {}
             log_config["config"]["filters"] = {}
             log_config["config"]["log_paths"] = log_mapping[item]["source"]["path"]

--- a/service_discovery/discovery.py
+++ b/service_discovery/discovery.py
@@ -448,7 +448,7 @@ def add_logger_config(service_dict, service):
             log_config["name"] = item
             log_config["recommend"] = True
             log_config["selected"] = True
-	    if 'collection_type' in value and value['collection_type'] == 'metric':
+            if 'collection_type' in value and value['collection_type'] == 'metric':
                 log_config['fluentd_type'] = "fluentd_agent"
             else:
                 log_config['fluentd_type'] = "fluentd_logging"


### PR DESCRIPTION
Update to file:
- logging_plugins_mapping.yaml: Added new field called 'collection_type' which specifies if the fluentd plugin is of type 'metric' or 'logger' (Defaults to 'logger')
- targets_mapping.yaml: Added the field 'store_type' as a valid parameter for targets
- fluentd_manager.py: Added code to check the 'collection_type' of a plugin, and based on that use appropriate es store using the 'store_type' field of the targets passed
- configurator.py: Added code to send 2 fluentd target types to the api /api/target/status differentiated by the key 'store_type'
- discovery.py: Added new field 'fluentd_type' while adding logger config, to differentiate between the collection type of loggers. The field values are 'fluentd_agent' or 'fluent_logging'
- Test cases to be attached in appBox