### PR TITLE
Support for geoip filter for fluentd plugins

### DIFF
--- a/config_handler/mapping/logging_plugins_mapping.yaml
+++ b/config_handler/mapping/logging_plugins_mapping.yaml
@@ -143,6 +143,8 @@ apache-access:
      level: 'info'
 #     message: "${record['method'] + ' ' + record['path'] + ' ' + record['code']}"
      path: ${if record['path'] != nil then record['path'] elsif record['id2'] == nil then record['path1'] + '[id]' + record['path2'] else record['path1'] + '[id]' + record['path2'] + '[id]' + record['path3'] end}
+   geotag:
+     geoip_lookup_keys: host
    match:
      flush_interval: 30s
 

--- a/config_handler/mapping/logging_plugins_mapping.yaml
+++ b/config_handler/mapping/logging_plugins_mapping.yaml
@@ -138,6 +138,8 @@ apache-access:
      time: ${require 'time'; time.to_time.to_i}
      level: 'info'
      message: "${record['method'] + ' ' + record['path'] + ' ' + record['code']}"
+   geotag:
+     geoip_lookup_keys: host
    match:
      flush_interval: 30s
 
@@ -234,6 +236,8 @@ nginx-access:
     time: ${require 'time'; time.to_time.to_i}
     level: 'info'
     path: ${if record['path'] != nil then record['path'] elsif record['id2'] == nil then record['path1'] + '[id]' + record['path2'] else record['path1'] + '[id]' + record['path2'] + '[id]' + record['path3'] end}
+  geotag:
+    geoip_lookup_keys: host
   match:
     flush_interval: 30s
 


### PR DESCRIPTION
Update:
- Added support to include geoip configuration to td-agent, if specified in the logging_plugins_mapping.yaml
- To add geoip support to a fluentd plugin, add the following lines to its config in the mapping file:
  "geoip:
     geoip_lookup_keys: <key>"
  where <key> is the field in the record which holds the ip address to lookup

Tested:
- Successfully tested for nginx and apache access plugins